### PR TITLE
docs: add SSH CLI authentication URL transfer exercise

### DIFF
--- a/exercises/ssh-cli-auth-transfer.md
+++ b/exercises/ssh-cli-auth-transfer.md
@@ -127,6 +127,8 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
    ```
 
 2. **Resume Claude CLI setup** on the ThinkPad with the token (if required).
+   
+   **Note:** On the text-only ThinkPad, copying the token from the file to the prompt requires using nano's visual mode (unlike the graphical machine). This contrast in text handling between environments is an interesting challenge. Be aware that if the process takes too long (30+ minutes), you might encounter an "OAuth error: Invalid state parameter" and need to restart.
 
 ## Alternative Approaches
 

--- a/exercises/ssh-cli-auth-transfer.md
+++ b/exercises/ssh-cli-auth-transfer.md
@@ -146,6 +146,8 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
    ```
    
    **Note:** While scanning the QR code is convenient, you may end up with a verification code on your smartphone that still needs to be transferred back to the ThinkPad. This creates another transfer challenge and isn't a complete solution by itself.
+   
+   **Additional challenge:** When trying to manually type the verification code from smartphone back into the terminal, errors are common. Attempting this resulted in "OAuth error: Request failed with status code 400" - likely due to typos or character mismatches when manually entering the code.
 
 2. **Using Magic Wormhole** for direct secure transfer:
    ```bash

--- a/exercises/ssh-cli-auth-transfer.md
+++ b/exercises/ssh-cli-auth-transfer.md
@@ -107,17 +107,14 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
    
    **Note:** Replace `<username>` with your ThinkPad username (run `whoami` on ThinkPad to check) and `<ip-address>` with the IP address from step 4.
 
-2. **View the authentication URL**:
-   ```bash
-   cat ~/claude-auth-url.txt
-   ```
-
-3. **Alternative: Copy the URL directly**:
+2. **Use SCP to securely copy the URL file**:
    ```bash
    # From visual browser machine
    scp <username>@<ip-address>:~/claude-auth-url.txt ./
    cat claude-auth-url.txt
    ```
+   
+   SCP (Secure Copy Protocol) is built on SSH and allows you to securely transfer files between computers. This approach is much more reliable than trying to copy text from an SSH terminal session, which often doesn't integrate well with the system clipboard.
 
 4. **Open the URL in a graphical browser** on your modern machine, complete the authentication process.
 

--- a/exercises/ssh-cli-auth-transfer.md
+++ b/exercises/ssh-cli-auth-transfer.md
@@ -100,25 +100,20 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
 
 ### Part 3: Transfer and Use the URL on Visual Browser Machine
 
-1. **From your machine with a visual browser, connect to the ThinkPad**:
-   ```bash
-   ssh <username>@<ip-address>
-   ```
-   
-   **Note:** Replace `<username>` with your ThinkPad username (run `whoami` on ThinkPad to check) and `<ip-address>` with the IP address from step 4.
-
-2. **Use SCP to securely copy the URL file**:
+1. **Use SCP to securely copy the URL file**:
    ```bash
    # From visual browser machine
    scp <username>@<ip-address>:~/claude-auth-url.txt ./
    cat claude-auth-url.txt
    ```
    
+   **Note:** Replace `<username>` with your ThinkPad username (run `whoami` on ThinkPad to check) and `<ip-address>` with the IP address from step 4.
+   
    SCP (Secure Copy Protocol) is built on SSH and allows you to securely transfer files between computers. This approach is much more reliable than trying to copy text from an SSH terminal session, which often doesn't integrate well with the system clipboard.
 
-4. **Open the URL in a graphical browser** on your modern machine, complete the authentication process.
+2. **Open the URL in a graphical browser** on your modern machine, complete the authentication process.
 
-5. **Copy the resulting authentication token** (if any) to transfer back to the ThinkPad.
+3. **Copy the resulting authentication token** (if any) to transfer back to the ThinkPad.
 
 ### Part 4: Complete Authentication on ThinkPad
 

--- a/exercises/ssh-cli-auth-transfer.md
+++ b/exercises/ssh-cli-auth-transfer.md
@@ -149,37 +149,14 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
    
    **Additional challenge:** When trying to manually type the verification code from smartphone back into the terminal, errors are common. Attempting this resulted in "OAuth error: Request failed with status code 400" - likely due to typos or character mismatches when manually entering the code.
 
-2. **Using Magic Wormhole** for direct secure transfer:
-   ```bash
-   # On both machines, install magic-wormhole
-   sudo pacman -S magic-wormhole
-   
-   # On ThinkPad
-   wormhole send ~/claude-auth-url.txt
-   
-   # On visual browser machine
-   wormhole receive <code-from-thinkpad>
-   ```
+## Conclusion: Success!
 
-3. **X11 Forwarding** to run a graphical browser through SSH:
-   ```bash
-   # From visual browser machine
-   ssh -X <username>@<ip-address>
-   
-   # On ThinkPad through SSH with X forwarding
-   firefox &  # If you have a graphical browser installed
-   ```
+I successfully authenticated Claude Code using the SCP method. The key was removing an extra space at the end of the verification code when yanking it in visual mode - this likely explains the earlier "Invalid state parameter" errors.
 
-## Reflection Questions
-
-1. What are the security implications of transferring authentication URLs between machines?
-2. How could this process be automated for regular use?
-3. What are the limitations of text-based browsers for modern web authentication?
-4. How might CLI tools better accommodate text-only environments?
-
-## Bonus Challenge
-
-Create a shell script that automates the process of extracting authentication URLs from CLI tools and generating QR codes for easy scanning with a smartphone.
+This exercise achieved:
+- Getting Claude Code working on a ThinkPad T400
+- Extending AI capabilities to older hardware
+- Demonstrating how SSH can bridge modern browser-based authentication with terminal-only environments
 
 ---
 

--- a/exercises/ssh-cli-auth-transfer.md
+++ b/exercises/ssh-cli-auth-transfer.md
@@ -53,13 +53,7 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
    sudo systemctl restart sshd
    ```
 
-4. **Find your IP address**:
-   ```bash
-   ip addr show | grep inet
-   ```
-   Note the IP address (usually starts with 192.168.x.x or 10.x.x.x)
-
-5. **Test SSH locally**:
+4. **Test SSH locally**:
    ```bash
    ssh localhost
    ```
@@ -92,15 +86,21 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
    ```
    This will prompt you with an authentication URL that you need to access.
 
-4. **Save the authentication URL**:
+4. **Find your ThinkPad's IP address** (needed for the next step):
+   ```bash
+   ip addr show | grep inet
+   ```
+   Note the IP address (usually starts with 192.168.x.x or 10.x.x.x)
+
+5. **Save the authentication URL**:
    ```bash
    # When Claude outputs the auth URL, save it to a file
    echo "https://long-authentication-url.example.com/with/many/parameters?and=values" > ~/claude-auth-url.txt
    ```
 
-### Part 3: Transfer and Use the URL on Modern Machine
+### Part 3: Transfer and Use the URL on Visual Browser Machine
 
-1. **From your modern machine, connect to the ThinkPad**:
+1. **From your machine with a visual browser, connect to the ThinkPad**:
    ```bash
    ssh username@thinkpad-ip-address
    ```
@@ -112,7 +112,7 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
 
 3. **Alternative: Copy the URL directly**:
    ```bash
-   # From modern machine
+   # From visual browser machine
    scp username@thinkpad-ip-address:~/claude-auth-url.txt ./
    cat claude-auth-url.txt
    ```
@@ -125,7 +125,7 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
 
 1. **If a token is provided after authentication**, transfer it back:
    ```bash
-   # On modern machine, save the token
+   # On visual browser machine, save the token
    echo "your-authentication-token" > claude-token.txt
    
    # Transfer to ThinkPad
@@ -155,13 +155,13 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
    # On ThinkPad
    wormhole send ~/claude-auth-url.txt
    
-   # On modern machine
+   # On visual browser machine
    wormhole receive [code-from-thinkpad]
    ```
 
 3. **X11 Forwarding** to run a graphical browser through SSH:
    ```bash
-   # From modern machine
+   # From visual browser machine
    ssh -X username@thinkpad-ip-address
    
    # On ThinkPad through SSH with X forwarding

--- a/exercises/ssh-cli-auth-transfer.md
+++ b/exercises/ssh-cli-auth-transfer.md
@@ -102,8 +102,10 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
 
 1. **From your machine with a visual browser, connect to the ThinkPad**:
    ```bash
-   ssh username@thinkpad-ip-address
+   ssh <username>@<ip-address>
    ```
+   
+   **Note:** Replace `<username>` with your ThinkPad username (run `whoami` on ThinkPad to check) and `<ip-address>` with the IP address from step 4.
 
 2. **View the authentication URL**:
    ```bash
@@ -113,7 +115,7 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
 3. **Alternative: Copy the URL directly**:
    ```bash
    # From visual browser machine
-   scp username@thinkpad-ip-address:~/claude-auth-url.txt ./
+   scp <username>@<ip-address>:~/claude-auth-url.txt ./
    cat claude-auth-url.txt
    ```
 
@@ -129,7 +131,7 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
    echo "your-authentication-token" > claude-token.txt
    
    # Transfer to ThinkPad
-   scp claude-token.txt username@thinkpad-ip-address:~/
+   scp claude-token.txt <username>@<ip-address>:~/
    ```
 
 2. **Resume Claude CLI setup** on the ThinkPad with the token (if required).
@@ -156,13 +158,13 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
    wormhole send ~/claude-auth-url.txt
    
    # On visual browser machine
-   wormhole receive [code-from-thinkpad]
+   wormhole receive <code-from-thinkpad>
    ```
 
 3. **X11 Forwarding** to run a graphical browser through SSH:
    ```bash
    # From visual browser machine
-   ssh -X username@thinkpad-ip-address
+   ssh -X <username>@<ip-address>
    
    # On ThinkPad through SSH with X forwarding
    firefox &  # If you have a graphical browser installed

--- a/exercises/ssh-cli-auth-transfer.md
+++ b/exercises/ssh-cli-auth-transfer.md
@@ -144,6 +144,8 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
    
    # Scan with smartphone and complete auth there
    ```
+   
+   **Note:** While scanning the QR code is convenient, you may end up with a verification code on your smartphone that still needs to be transferred back to the ThinkPad. This creates another transfer challenge and isn't a complete solution by itself.
 
 2. **Using Magic Wormhole** for direct secure transfer:
    ```bash

--- a/exercises/ssh-cli-auth-transfer.md
+++ b/exercises/ssh-cli-auth-transfer.md
@@ -129,6 +129,8 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
 2. **Resume Claude CLI setup** on the ThinkPad with the token (if required).
    
    **Note:** On the text-only ThinkPad, copying the token from the file to the prompt requires using nano's visual mode (unlike the graphical machine). This contrast in text handling between environments is an interesting challenge. Be aware that if the process takes too long (30+ minutes), you might encounter an "OAuth error: Invalid state parameter" and need to restart.
+   
+   **Learning curve:** While the first attempt might take 20-30 minutes, subsequent attempts can be completed in under a minute once you have the commands in your history and understand the workflow. However, OAuth errors may still occur due to security features like session expiration, token reuse prevention, or state parameter validation. Solving these authentication challenges is an exercise for later exploration.
 
 ## Alternative Approaches
 

--- a/exercises/ssh-cli-auth-transfer.md
+++ b/exercises/ssh-cli-auth-transfer.md
@@ -41,9 +41,13 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
    # Edit SSH configuration
    sudo nano /etc/ssh/sshd_config
    
-   # Ensure these lines are uncommented:
+   # Look for these lines (they might be commented with # at the beginning):
    # ListenAddress 0.0.0.0
    # PasswordAuthentication yes
+   # (Note: These lines might not be next to each other - use Ctrl+W to search)
+   
+   # Remove the # at the beginning of each line if present
+   # When done, save with Ctrl+O, then Enter, and exit with Ctrl+X
    
    # Restart SSH after changes
    sudo systemctl restart sshd
@@ -59,6 +63,16 @@ You're working with a text-only Arch Linux installation on an older ThinkPad T40
    ```bash
    ssh localhost
    ```
+   
+   You'll likely see this warning:
+   ```
+   The authenticity of host 'localhost (::1)' can't be established.
+   ED25519 key fingerprint is SHA256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.
+   This key is not known by any other names.
+   Are you sure you want to continue connecting (yes/no/[fingerprint])?
+   ```
+   
+   This is normal and expected! Type `yes` and press Enter. This warning appears because this is your first SSH connection to this server, and SSH is protecting you from potential man-in-the-middle attacks. After connecting once, the key will be stored in your `~/.ssh/known_hosts` file and you won't see this warning again.
 
 ### Part 2: Initial Claude CLI Setup on ThinkPad
 

--- a/exercises/ssh-cli-auth-transfer.md
+++ b/exercises/ssh-cli-auth-transfer.md
@@ -1,0 +1,170 @@
+# SSH Authentication URL Transfer Exercise
+
+This exercise addresses a common real-world scenario: securely transferring a long authentication URL between machines when one has limited capabilities.
+
+## Actual Use Case
+
+You're working with a text-only Arch Linux installation on an older ThinkPad T400. You need to authenticate the Claude CLI (Anthropic's AI assistant), which requires accessing a long authentication URL. The text-based browsers available (w3m, lynx, etc.) are struggling with the modern authentication page, and manually typing the URL would be error-prone and tedious.
+
+## Learning Objectives
+
+- Set up SSH connections between computers with different capabilities
+- Transfer authentication URLs or tokens securely
+- Work around limitations of older hardware
+- Implement practical solutions for CLI tool authentication
+- Understand the challenges of text-only environments
+
+## Prerequisites
+
+- A text-only Linux machine (like a ThinkPad T400 with Arch Linux)
+- A modern computer with graphical browser capabilities
+- Network connectivity between machines
+- Basic command line knowledge
+
+## Exercise Steps
+
+### Part 1: Prepare the Source Machine (ThinkPad T400)
+
+1. **Install OpenSSH** if not already installed:
+   ```bash
+   sudo pacman -S openssh
+   ```
+
+2. **Start the SSH service**:
+   ```bash
+   sudo systemctl start sshd
+   sudo systemctl status sshd  # Verify it's running
+   ```
+
+3. **Troubleshooting "Connection refused" errors**:
+   ```bash
+   # Edit SSH configuration
+   sudo nano /etc/ssh/sshd_config
+   
+   # Ensure these lines are uncommented:
+   # ListenAddress 0.0.0.0
+   # PasswordAuthentication yes
+   
+   # Restart SSH after changes
+   sudo systemctl restart sshd
+   ```
+
+4. **Find your IP address**:
+   ```bash
+   ip addr show | grep inet
+   ```
+   Note the IP address (usually starts with 192.168.x.x or 10.x.x.x)
+
+5. **Test SSH locally**:
+   ```bash
+   ssh localhost
+   ```
+
+### Part 2: Initial Claude CLI Setup on ThinkPad
+
+1. **Install Node.js and npm** (required for Claude CLI):
+   ```bash
+   sudo pacman -S nodejs npm
+   ```
+
+2. **Install Claude CLI**:
+   ```bash
+   npm install -g @anthropic-ai/claude-code
+   ```
+
+3. **Begin Claude authentication process**:
+   ```bash
+   claude
+   ```
+   This will prompt you with an authentication URL that you need to access.
+
+4. **Save the authentication URL**:
+   ```bash
+   # When Claude outputs the auth URL, save it to a file
+   echo "https://long-authentication-url.example.com/with/many/parameters?and=values" > ~/claude-auth-url.txt
+   ```
+
+### Part 3: Transfer and Use the URL on Modern Machine
+
+1. **From your modern machine, connect to the ThinkPad**:
+   ```bash
+   ssh username@thinkpad-ip-address
+   ```
+
+2. **View the authentication URL**:
+   ```bash
+   cat ~/claude-auth-url.txt
+   ```
+
+3. **Alternative: Copy the URL directly**:
+   ```bash
+   # From modern machine
+   scp username@thinkpad-ip-address:~/claude-auth-url.txt ./
+   cat claude-auth-url.txt
+   ```
+
+4. **Open the URL in a graphical browser** on your modern machine, complete the authentication process.
+
+5. **Copy the resulting authentication token** (if any) to transfer back to the ThinkPad.
+
+### Part 4: Complete Authentication on ThinkPad
+
+1. **If a token is provided after authentication**, transfer it back:
+   ```bash
+   # On modern machine, save the token
+   echo "your-authentication-token" > claude-token.txt
+   
+   # Transfer to ThinkPad
+   scp claude-token.txt username@thinkpad-ip-address:~/
+   ```
+
+2. **Resume Claude CLI setup** on the ThinkPad with the token (if required).
+
+## Alternative Approaches
+
+1. **QR Code Method**:
+   ```bash
+   # On ThinkPad, install qrencode
+   sudo pacman -S qrencode
+   
+   # Generate QR code from auth URL
+   qrencode -t ANSIUTF8 -o - "$(cat ~/claude-auth-url.txt)"
+   
+   # Scan with smartphone and complete auth there
+   ```
+
+2. **Using Magic Wormhole** for direct secure transfer:
+   ```bash
+   # On both machines, install magic-wormhole
+   sudo pacman -S magic-wormhole
+   
+   # On ThinkPad
+   wormhole send ~/claude-auth-url.txt
+   
+   # On modern machine
+   wormhole receive [code-from-thinkpad]
+   ```
+
+3. **X11 Forwarding** to run a graphical browser through SSH:
+   ```bash
+   # From modern machine
+   ssh -X username@thinkpad-ip-address
+   
+   # On ThinkPad through SSH with X forwarding
+   firefox &  # If you have a graphical browser installed
+   ```
+
+## Reflection Questions
+
+1. What are the security implications of transferring authentication URLs between machines?
+2. How could this process be automated for regular use?
+3. What are the limitations of text-based browsers for modern web authentication?
+4. How might CLI tools better accommodate text-only environments?
+
+## Bonus Challenge
+
+Create a shell script that automates the process of extracting authentication URLs from CLI tools and generating QR codes for easy scanning with a smartphone.
+
+---
+
+*Note: This exercise was created based on a real-world challenge with authenticating CLI tools on text-only Linux systems. The approach can be applied to many modern CLI tools that require web authentication.*


### PR DESCRIPTION
This PR adds a new exercise document that explains how to securely transfer authentication URLs between machines when one has limited capabilities.

The exercise addresses a real-world scenario of authenticating CLI tools on a text-only Arch Linux system, specifically focusing on Claude CLI authentication.

Key features:
- Step-by-step instructions for SSH setup
- Multiple approaches for URL transfer
- Troubleshooting common issues
- Alternative methods like QR codes and Magic Wormhole