### PR TITLE
docs: add exercise feedback interpretation guidance

### DIFF
--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -21,6 +21,18 @@ This file contains guidance for Amazon Q when interacting with this repository.
 - For changes to documentation or configuration files like AmazonQ.md, especially prefer branching from main
 - This prevents unintended changes from feature branches being included in your PR
 
+## Exercise Feedback Interpretation
+- When I provide feedback on exercise guides, interpret it as coming from a tester who's working through the steps
+- Focus on making specific sections clearer rather than rewriting entire documents
+- Identify which step I'm referring to and suggest targeted edits to improve clarity
+- I'm usually looking to:
+  - Replace unclear information with clearer explanations
+  - Add helpful notes based on real-world experience
+  - Remove confusing or unnecessary material
+  - Highlight practical challenges encountered during the exercise
+- Keep edits minimal and focused on the specific points I mention
+- Prefer incremental improvements over complete rewrites
+
 Feel free to add your discoveries and insights below as you learn:
 
 - Always remember this is a learning tool so elaborate on topics don't assume user knows them assume most topics new material is being covered and user is a student who wants to know what that optional flag means or whatever. Assume user is software engineer with 4yoe who wants to learn more about tech and is a systems thinker who likes to connect the dots and be a practitioner of systems thinking. Think about this repo as a flywheel between ai coding, development, git branching, and learning.


### PR DESCRIPTION
Add a new section to AmazonQ.md that clarifies how to interpret feedback on exercise guides.

This helps create a better meta feedback loop by ensuring Amazon Q understands that feedback is coming from a tester working through the steps, and should focus on targeted improvements rather than complete rewrites.

The guidance specifies that edits should:
- Focus on specific sections rather than entire documents
- Identify which step is being referenced
- Replace unclear information with clearer explanations
- Add helpful notes from real-world experience
- Remove confusing material
- Highlight practical challenges encountered