### PR TITLE
docs: enhance About You section to highlight dotfile expectations

### DIFF
--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -49,6 +49,7 @@ Feel free to add your discoveries and insights below as you learn:
 - 32-year-old male software engineer with 4 YOE working remotely
 - Former bodybuilder and IFBB Men's Physique competitor with pro card ambitions
 - Passionate about developer productivity and systems thinking
+- Tracks dotfiles as meticulously as macros - expects tools to respect personal configurations
 - Committed to daily 1% improvements in technical skills
 - Seeking to apply the same discipline from fitness to technical mastery
 


### PR DESCRIPTION
This PR adds a subtle but important detail to the About You section that signals to Amazon Q that the user meticulously maintains their dotfiles and expects tools to respect personal configurations.

This change helps create a more personalized experience by encouraging Amazon Q to check relevant configuration files before making assumptions about default settings, especially for keyboard shortcuts and tool commands.

Rather than explicitly instructing Amazon Q to check specific files, this approach drops a meaningful clue that a smart AI coach should pick up on - creating that 'magical mind-reader' experience without being overly prescriptive.