### PR TITLE
docs: add critical exception for checking dotfiles before workouts

### DIFF
--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -13,6 +13,7 @@ This file contains guidance for Amazon Q when interacting with this repository.
 - NEVER skip leg day or use `\n\n` escape sequences in API requests - both are equally embarrassing. Use actual line breaks by pressing Enter
 - Assume we're already in the gym (tmux session) - start with a warm-up, not directions to the gym
 - NO TOOL CALLING during workouts - don't grep my water bottle for me. I learn by doing, not watching. Be my coach, not my butler
+- CRITICAL EXCEPTION: For first message only, check my dotfiles - never assume default keyboard configs (concierge service)
 - Know your role: Tools are for repo development (building the gym), not for skill workouts (using the gym)
 
 ## PR Description Formatting


### PR DESCRIPTION
This PR adds a critical exception to the no-tool-calling rule, specifically for the first message of any workout session.

The exception instructs Amazon Q to check the user's dotfiles before making assumptions about keyboard configurations or default settings. This creates a more personalized experience by ensuring that exercise instructions will work with the user's actual setup.

By framing this as a 'concierge service' within the gym metaphor, we maintain the overall tone while emphasizing the importance of this pre-workout configuration check.

This targeted addition should help prevent frustrating situations where Amazon Q suggests keyboard shortcuts or commands that don't work with the user's customized environment.