### PR TITLE
docs: restructure README to focus on INSTRUCTIONS.json structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,77 @@
 # Tech Skills Gym
 
-A personal training ground where I apply progressive overload principles from bodybuilding to technical skill development.
+A training ground applying progressive overload principles to technical skill development.
 
-## About Me
+## How to Use
 
-- 32-year-old software engineer with 4 YOE working remotely
-- Former competitive gamer who discovered that the same grinding mindset works for bodybuilding and coding
-- Transformed physique using "IFBB competitor" AI prompts in my apartment gym - now applying the same mental hack to technical skills
-- No formal CS education - completely self-taught through an inherent desire to level up skills
-- Not just a techbro or fitness guy - fundamentally a systems thinker obsessed with learning frameworks
-- Tracks dotfiles as meticulously as macros - nothing exists without purpose
-- Committed to daily 1% improvements that compound into expertise
+1. Start a new ChatGPT or Claude project
+2. Link it to: `https://raw.githubusercontent.com/atxtechbro/tech-skills-gym/refs/heads/main/INSTRUCTIONS.json`
+3. Begin your training session with: "spot me bro [focus area]"
 
-## Core Philosophy
+That's it! The AI will guide you through progressive technical exercises following the training framework.
 
-Technical mastery follows the same feedback loops as physical training:
-- Set clear goals → Track performance → Identify weaknesses → Target challenges → Progressive skill building
-- A craftsman must understand their tools completely - I refuse to use anything I don't understand
-- Build in public, track everything with git, and learn through iteration, not perfection
+## What's in INSTRUCTIONS.json
 
-## What's Here
+The framework is organized into several key sections:
 
-This repo serves as my AI-powered coaching environment - creating a flywheel between:
-- Structured learning paths with progressive difficulty
-- Personalized technical exercises following the 5% rule (just beyond comfort zone)
-- Systems thinking approach connecting isolated skills into cohesive expertise
-- [Sandbox environments](SANDBOX.md) for safe experimentation - like a playground where you can run wild with commands without fear of breaking your system
-  - Every learner needs a safe space to make mistakes and experiment freely
-  - Our sandbox setup script creates isolated environments where you can practice destructive operations
-  - Run `./setup-sandbox.sh` to create your own training ground
-- [Training framework and methodology](INSTRUCTIONS.json) - detailed structure for progressive skill development
+### Meta
+- Description of the technical skills gym concept
 
-## Future Pipeline
+### Goals
+- Primary objective
+- Philosophy
+- Approach to skill development
 
-- GitHub Actions to automate learning module delivery when PRs are merged in any repo
-- Creating learning session issues to track progress and insights
-- Sharing modules with others to gather feedback on their tech learning journeys
-- Iterating based on real-world application, not theoretical perfection
-- Pull vs push attitude: letting curiosity drive learning rather than rigid formulas
+### Training Framework
+- Principles for effective skill building
+- Progression model
+  - Difficulty calibration (5% rule)
+  - Feedback loop
+  - Tracking progress
 
-## Connect
+### Session Structure
+- Format for interactive learning
+- Flow
+  - Warm-up phase
+  - Main sets phase
+  - Cool-down phase
+- Progression approach
 
-- [My dotfiles](https://github.com/atxtechbro/dotfiles) - Configuration as meticulously tracked as macros
-- [GitHub profile](https://github.com/atxtechbro) - Where my passion for continuous learning lives
+### Interaction Protocol
+- Initiation process
+- Delivery style
+- Feedback mechanism
+- Adaptation based on performance
+- Continuation options
 
-## Current Focus
+### Agent Responsibilities
+- What the AI should provide
+- What the AI should avoid
+- Critical guidelines
 
-Backend, Linux, CI/CD, operating systems, and hardware - grinding skills with the same dedication I once applied to level 99 woodcutting in RuneScape, but with exponentially greater returns. Each 1% daily improvement compounds into human capital that creates leveraged value in a software-defined world.
+### User Responsibilities
+- Expected user contributions
+- Commitment to the process
 
-Like a blacksmith mastering their hammer or a woodworker their chisel, I'm building deep expertise in the tools that shape my craft.
+### Technical Focus Areas
+- Primary skill domains
+- Development approach
+
+### Ethos
+- Mindset for effective learning
+- Identity as a learner
+- Commitment to mastery
+
+## Sandbox Environment
+
+For safe experimentation:
+- Run `./setup-sandbox.sh` to create isolated environments
+- Practice destructive operations without fear of breaking your system
+
+## Philosophy
+
+This gym applies bodybuilding principles to technical skills:
+- Progressive overload (gradually increasing difficulty)
+- Consistent practice with feedback loops
+- Targeted exercises for specific skill development
+- One exercise at a time - mastery through focus


### PR DESCRIPTION
This PR updates the README.md to focus specifically on the structure of INSTRUCTIONS.json and how to use it.

Changes:
- Removed personal information and moved it to a private location
- Added detailed breakdown of each section in INSTRUCTIONS.json
- Organized content to highlight the framework's components
- Maintained simple 'How to Use' instructions
- Kept the sandbox environment and philosophy sections

The README now serves as a clear guide for new users to understand and utilize the training framework.