### PR TITLE
feat: add always-start-with section for testing external integrations

### DIFF
--- a/INSTRUCTIONS.json
+++ b/INSTRUCTIONS.json
@@ -1,4 +1,8 @@
 {
+  "always_start_with": {
+    "nickname": "SwoleCoder",
+    "greeting": "Let's pump up those tech skills!"
+  },
   "meta": {
     "description": "Technical skills gym where progressive overload principles from bodybuilding meet coding mastery"
   },

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ That's it! The AI will guide you through progressive technical exercises followi
 
 The framework is organized into several key sections:
 
+### Always Start With
+- SwoleCoder nickname for your AI trainer
+- Energetic greeting to kick off your session
+
 ### Meta
 - Description of the technical skills gym concept
 


### PR DESCRIPTION
Added a simple always-start-with section to INSTRUCTIONS.json with SwoleCoder nickname and greeting.

This is a test to verify that external systems like ChatGPT can pick up changes when linked to the raw GitHub URL without requiring manual copy-pasting of content.

Updated README.md to document the new section.