### PR TITLE
docs: add diverse user prompt examples for test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ A training ground applying progressive overload principles to technical skill de
 
 That's it! The AI will guide you through progressive technical exercises following the training framework.
 
+## Example Training Prompts
+
+Here are some examples of how users might start their training sessions:
+
+- `spot me bro kubernetes - i'm trying to learn about service meshes`
+- `hey spot me bro with some golang, i've been coding for about 2 years`
+- `SPOT ME BRO! need to get better at system design interviews ASAP!!`
+- `spot me bro bash scripting please. i'm a complete beginner.`
+- `can you spot me on react hooks? i understand components but hooks confuse me`
+
+The AI trainer will adapt to different styles, experience levels, and specific focus areas within each technical domain.
+
 ## What's in INSTRUCTIONS.json
 
 The framework is organized into several key sections:

--- a/README.md
+++ b/README.md
@@ -12,15 +12,11 @@ That's it! The AI will guide you through progressive technical exercises followi
 
 ## Example Training Prompts
 
-Here are some examples of how users might start their training sessions:
-
 - `spot me bro kubernetes - i'm trying to learn about service meshes`
 - `hey spot me bro with some golang, i've been coding for about 2 years`
 - `SPOT ME BRO! need to get better at system design interviews ASAP!!`
 - `spot me bro bash scripting please. i'm a complete beginner.`
 - `can you spot me on react hooks? i understand components but hooks confuse me`
-
-The AI trainer will adapt to different styles, experience levels, and specific focus areas within each technical domain.
 
 ## What's in INSTRUCTIONS.json
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A training ground applying progressive overload principles to technical skill de
 
 That's it! The AI will guide you through progressive technical exercises following the training framework.
 
-## Example Training Prompts
+## Example Initial User Inputs
 
 - `spot me bro kubernetes - i'm trying to learn about service meshes`
 - `hey spot me bro with some golang, i've been coding for about 2 years`


### PR DESCRIPTION
Added 5 diverse examples of how users might interact with the tech-skills-gym.

These examples showcase different:
- Experience levels (beginner to experienced)
- Writing styles (casual to urgent)
- Technical domains (kubernetes, golang, system design, bash, react)
- Specificity levels (general topics to specific focus areas)

These examples will be useful for testing the AI's ability to adapt to different user inputs and styles.