### PR TITLE
docs: update README with instructions for ChatGPT Projects feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@ A training ground applying progressive overload principles to technical skill de
 
 ## How to Use
 
-1. Start a new ChatGPT or Claude project
+### For ChatGPT:
+1. Start a new ChatGPT conversation
+2. Click on "Custom instructions" in the settings
+3. In the "How would you like ChatGPT to respond?" section, paste:
+   ```
+   Please load and follow the instructions from this URL: https://raw.githubusercontent.com/atxtechbro/tech-skills-gym/refs/heads/main/INSTRUCTIONS.json
+   ```
+4. Alternatively, use the ChatGPT Advanced Data Analysis feature and ask it to:
+   ```
+   curl https://raw.githubusercontent.com/atxtechbro/tech-skills-gym/refs/heads/main/INSTRUCTIONS.json | jq
+   ```
+   Then ask it to "Follow these instructions for our conversation"
+5. Begin your training session with: "spot me bro [focus area]"
+
+### For Claude:
+1. Start a new Claude conversation
 2. Link it to: `https://raw.githubusercontent.com/atxtechbro/tech-skills-gym/refs/heads/main/INSTRUCTIONS.json`
 3. Begin your training session with: "spot me bro [focus area]"
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,26 @@ A training ground applying progressive overload principles to technical skill de
 ## How to Use
 
 ### For ChatGPT:
-1. Start a new ChatGPT conversation
-2. Click on "Custom instructions" in the settings
-3. In the "How would you like ChatGPT to respond?" section:
+1. Create a dedicated project:
+   - Click on "Projects" in the left sidebar
+   - Click "+ New project"
+   - Enter name "tech-skills-gym" (or your preferred name)
+   - Click "Create project"
+
+2. Add custom instructions to your project:
+   - Under your new project, click "Add instructions"
    - Visit: https://raw.githubusercontent.com/atxtechbro/tech-skills-gym/refs/heads/main/INSTRUCTIONS.json
    - Press Ctrl+A to select all content
    - Copy the entire content (Ctrl+C)
-   - Paste it into the custom instructions field (Ctrl+V)
+   - Paste it into the project instructions field (Ctrl+V)
+   - Save the instructions
 
-4. Begin your training session with: "spot me bro [focus area]"
+3. Begin your training session with: "spot me bro [focus area]"
+
+4. You can create multiple sessions within this project for different focus areas:
+   - "spot me bro kubernetes"
+   - "spot me bro golang"
+   - etc.
 
 ### For Claude:
 1. Start a new Claude conversation

--- a/README.md
+++ b/README.md
@@ -7,16 +7,13 @@ A training ground applying progressive overload principles to technical skill de
 ### For ChatGPT:
 1. Start a new ChatGPT conversation
 2. Click on "Custom instructions" in the settings
-3. In the "How would you like ChatGPT to respond?" section, paste:
-   ```
-   Please load and follow the instructions from this URL: https://raw.githubusercontent.com/atxtechbro/tech-skills-gym/refs/heads/main/INSTRUCTIONS.json
-   ```
-4. Alternatively, use the ChatGPT Advanced Data Analysis feature and ask it to:
-   ```
-   curl https://raw.githubusercontent.com/atxtechbro/tech-skills-gym/refs/heads/main/INSTRUCTIONS.json | jq
-   ```
-   Then ask it to "Follow these instructions for our conversation"
-5. Begin your training session with: "spot me bro [focus area]"
+3. In the "How would you like ChatGPT to respond?" section:
+   - Visit: https://raw.githubusercontent.com/atxtechbro/tech-skills-gym/refs/heads/main/INSTRUCTIONS.json
+   - Press Ctrl+A to select all content
+   - Copy the entire content (Ctrl+C)
+   - Paste it into the custom instructions field (Ctrl+V)
+
+4. Begin your training session with: "spot me bro [focus area]"
 
 ### For Claude:
 1. Start a new Claude conversation


### PR DESCRIPTION
Updated the README.md to provide instructions for using ChatGPT's Projects feature:

- Added steps to create a dedicated project for tech-skills-gym
- Included instructions for adding the INSTRUCTIONS.json content to project instructions
- Explained how to create multiple sessions within the same project for different focus areas
- Maintained the manual copy/paste approach with keyboard shortcuts